### PR TITLE
Fix conflict with html2jade-plus

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -38,7 +38,7 @@ module.exports =
 
 	onDidOpenFile: (event) ->
 		# Disable it of uri is an internal page
-		if event.uri.substring(0, 7) isnt 'atom://'
+		if event.uri?.substring(0, 7) isnt 'atom://'
 
 			if event.item.getGrammar() is atom.grammars.nullGrammar
 				newGrammar = atom.config.get('default-language.defaultLanguage')


### PR DESCRIPTION
In html2jade-plus, i open a new empty text editor with `atom.workspace.open()` and then fill it once the promise is resolved. This is broken because atom-default-language would throw an error here.
