### PR TITLE
Add check that name is not null before using it.

### DIFF
--- a/lib/index.coffee
+++ b/lib/index.coffee
@@ -51,6 +51,6 @@ module.exports =
         if newGrammar isnt 'Disabled'
 
           for grammar in atom.grammars.grammars
-            if grammar.name.toLowerCase().replace(/\ /g, '') is newGrammar.toLowerCase().replace(/\ /g, '')
+            if grammar.name && grammar.name.toLowerCase().replace(/\ /g, '') is newGrammar.toLowerCase().replace(/\ /g, '')
               item.setGrammar(grammar)
               break


### PR DESCRIPTION
Fixes #6

This just adds a check that grammar.name is not null before using it.